### PR TITLE
Add character limits for task title (80) and description (240)

### DIFF
--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -60,15 +60,19 @@ export default function TaskForm({
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           className={`w-full placeholder-white text-white px-3 py-2 bg-slate-800 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-            errors.title ? "border-red-500" : "border-slate-800"
+            errors.title ? "border-red-400" : title.length === 80 ? " bg-slate-800 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-red-400" : " bg-slate-800 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           }`}
           placeholder="Ingresa el título de la tarea"
+          maxLength={80}
           required
         />
-        {errors.title && <p className="text-red-600 text-sm">{errors.title}</p>}
+        <div>
+          {errors.title && <p className="text-red-600 text-sm">{errors.title}</p>}
+          <p className={`text-gray-400 text-xs text-right py-2 ${title.length === 80 ? 'text-red-500' : 'text-gray-400'}`}>{title.length}/80 caracteres</p>
+        </div>
       </div>
 
-      <div className="space-y-1">
+      <div className="space-y-2">
         <label
           htmlFor="description"
           className="block text-sm font-medium text-gray-300"
@@ -79,10 +83,16 @@ export default function TaskForm({
           id="description"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
-          className="w-full px-3 py-2 border placeholder-white text-white bg-slate-800 border-slate-800 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          className={`w-full px-3 py-2 border placeholder-white text-white ${
+            description.length === 240 ? " bg-slate-800 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-red-500" : " bg-slate-800 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          }`}
           rows={3}
           placeholder="Describe la tarea (opcional)"
+          maxLength={240}
         />
+        <p className={`text-xs text-right ${description.length === 240 ? 'text-red-500' : 'text-gray-400'}`}>
+          {description.length}/240 caracteres
+        </p>
       </div>
 
       <div className="flex items-center">


### PR DESCRIPTION
- Enforced max length of 80 characters for titles and 240 for descriptions
- Character counters turn red when the limit is reached
- Input ring also turns red to visually indicate the limit